### PR TITLE
Update trafficmanager.json

### DIFF
--- a/arm-trafficmanager/2015-11-01/swagger/trafficmanager.json
+++ b/arm-trafficmanager/2015-11-01/swagger/trafficmanager.json
@@ -60,7 +60,7 @@
             "schema": {
               "$ref": "#/definitions/Endpoint"
             },
-            "description": "The Traffic Manager endpoint parameters supplied to the Update operation."
+            "description": "The Traffic Manager endpoint parameters supplied to the update operation."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -182,13 +182,13 @@
         ],
         "responses": {
           "200": { 
-             "description": "The created or updated Endpoint.", 
+             "description": "The created or updated endpoint.", 
              "schema": { 
                "$ref": "#/definitions/Endpoint" 
              } 
           },
           "201": { 
-             "description": "The created or updated Endpoint.", 
+             "description": "The created or updated endpoint.", 
              "schema": { 
                "$ref": "#/definitions/Endpoint" 
              } 
@@ -253,7 +253,7 @@
           "Profiles"
         ],
         "operationId": "Profiles_CheckTrafficManagerRelativeDnsNameAvailability",
-        "description": "Checks the availability of a Traffic Manager Relative DNS name.",
+        "description": "Checks the availability of a Traffic Manager relative DNS name.",
         "parameters": [
           {
             "name": "parameters",
@@ -486,8 +486,7 @@
             "description": "The name of the resource group containing the Traffic Manager profile."
           },
           {
-            "name": "profileName",
-            "in": "path",
+            "name": "profileName",            "in": "path",
             "required": true,
             "type": "string",
             "description": "The name of the Traffic Manager profile."
@@ -499,7 +498,7 @@
             "schema": {
               "$ref": "#/definitions/Profile"
             },
-            "description": "The Traffic Manager profile parameters supplied to the Update operation."
+            "description": "The Traffic Manager profile parameters supplied to the update operation."
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -532,7 +531,7 @@
         },
         "endpointStatus": {
           "type": "string",
-          "description": "Gets or sets the status of the endpoint..  If the endpoint is Enabled, it is probed for endpoint health and is included in the traffic routing method.  Possible values are 'Enabled' and 'Disabled'."
+          "description": "Gets or sets the status of the endpoint.  If the endpoint is enabled, it is probed for endpoint health and is included in the traffic routing method.  Possible values are 'Enabled' and 'Disabled'."
         },
         "weight": {
           "type": "integer",
@@ -542,7 +541,7 @@
         "priority": {
           "type": "integer",
           "format": "int64",
-          "description": "Gets or sets the priority of this endpoint when using the ‘Priority’ traffic routing method. Possible values are from 1 to 1000, lower values represent higher priority. This is an optional parameter.  If specified, it must be specified on all endpoints, and no two endpoints can share the same priority value."
+          "description": "Gets or sets the priority of this endpoint when using the ‘Priority’ traffic routing method. Possible values are from 1 to 1000; lower values represent higher priority. This is an optional parameter.  If specified, it must be specified on all endpoints, and no two endpoints can share the same priority value."
         },
         "endpointLocation": {
           "type": "string",
@@ -602,12 +601,12 @@
         },
         "fqdn": {
           "type": "string",
-          "description": "Gets or sets the fully-qualified domain name (FQDN) of the Traffic Manager profile.  This is formed from the concatenation of the RelativeName with the DNS domain used by Azure Traffic Manager."
+          "description": "Gets or sets the fully-qualified domain name (FQDN) of the Traffic Manager profile.  This is formed from the concatenation of the relative name with the DNS domain used by Azure Traffic Manager."
         },
         "ttl": {
           "type": "integer",
           "format": "int64",
-          "description": "Gets or sets the DNS Ttime-To-Live (TTL), in seconds.  This informs the local DNS resolvers and DNS clients how long to cache DNS responses provided by this Traffic Manager profile."
+          "description": "Gets or sets the DNS Time-To-Live (TTL) in seconds.  This tells the local DNS resolvers and DNS clients how long to cache DNS responses provided by this Traffic Manager profile."
         }
       },
       "description": "Class containing DNS settings in a Traffic Manager profile."
@@ -718,7 +717,7 @@
         "id": {
           "readOnly": true,
           "type": "string",
-          "description": "Resource Id"
+          "description": "Resource ID"
         },
         "name": {
           "readOnly": true,
@@ -748,7 +747,7 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Resource Id"
+          "description": "Resource ID"
         }
       },
       "x-ms-external": true
@@ -767,7 +766,7 @@
       "in": "query",
       "required": true,
       "type": "string",
-      "description": "Client Api Version."
+      "description": "Client API Version."
     }
   }
 }


### PR DESCRIPTION
This checklist is used to make sure that common issues in a pull request are addressed. This will expedite the process of getting your pull request merged and avoid extra work on your part to fix issues discovered during the review process. 
### PR information
- [ ] The title of the PR is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For information on cleaning up the commits in your pull request, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
- [ ] Except for special cases involving multiple contributors, the PR is started from a fork of the main repository, not a branch.
- [ ] If applicable, the PR references the bug/issue that it fixes.
- [ ] Swagger files are correctly named (e.g. the `api-version` in the path should match the `api-version` in the spec).
### Quality of Swagger
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-rest-api-specs/blob/master/.github/CONTRIBUTING.md).
- [ ] My spec meets the review criteria:
  - [ ] The spec conforms to the [Swagger 2.0 specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md).
  - [ ] Validation errors from the [Linter extension for VS Code](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/linter.md) have all been fixed for this spec. (**Note:** for large, previously checked in specs, there will likely be many errors shown. Please contact our team so we can set a timeframe for fixing these errors if your PR is not going to address them).
  - [ ] The spec follows the patterns described in the [Swagger good patterns](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-good-patterns.md) document unless the service API makes this impossible.
    Full review. There are missing status descriptions at lines 242, 245, 276, 311, 339, 467, 470.
